### PR TITLE
Adding support for an Apache reverse proxy in front of django

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,16 @@ The following configuration assumes that the apache mod_proxy is loaded as well 
       AuthType WebAuth
       require valid-user
       RequestHeader set "X-WEBAUTH-USER" "%{WEBAUTH_USER}e"
-    </location>
+RequestHeader unset X-Forwarded-Proto
+
+# set the header for requests using HTTPS
+RequestHeader set X-Forwarded-Proto https env=HTTPS
+</location>
+
+RequestHeader unset X-Forwarded-Proto
+
+# set the header for requests using HTTPS
+RequestHeader set X-Forwarded-Proto https env=HTTPS
 
 
     <Directory /path/to/my/site/static>
@@ -68,6 +77,9 @@ The following configuration assumes that the apache mod_proxy is loaded as well 
 
 
 As the request header has come from Apache it is prepended with HTTP_ by the time it gets to django hence the get statement in views.py.
+We must also allow proxying of HTTP requests in the django settings file:
+
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 
 LDAP configuration

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,39 @@ Follow the `OUCS documentation
 the Webauth login view. You may also wish to use the ``WebauthDoLogout``
 directive for the logout view.
 
+If you wish to run django in a light wsgi container such as uwsgi, gunicorn etc. It is possible to pass the webauth username to the local proxy server by setting an environmental variable in apache.
+
+The following configuration assumes that the apache mod_proxy is loaded as well as mod_webauth and is placed inside the virtualhost configuration. All directly served URLs such as static must be ignoged by using the syntax shown below
+
+<VirtualHost *:443>
+
+    ProxyPass / http://localhost:8080/
+    ProxyPassReverse / http://localhost:8080/
+    ProxyPass /static !
+    Alias /static /var/www/chembiohub/chembiohubhome/chembiohub/static
+
+
+    <Location />
+      WebAuthExtraRedirect on
+      AuthType WebAuth
+      require valid-user
+      RequestHeader set "X-WEBAUTH-USER" "%{WEBAUTH_USER}e"
+    </location>
+
+
+  <Directory /path/to/my/site/static>
+Options Indexes FollowSymLinks Includes
+        AllowOverride All
+        Order allow,deny
+        Allow from all
+
+</Directory>
+</VirtualHost>
+
+
+As the request header has come from Apache it is prepended with HTTP_ by the time it gets to django hence the get statement in views.py.
+
+
 LDAP configuration
 ~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,8 @@ The following configuration assumes that the apache mod_proxy is loaded as well 
 
     <VirtualHost *:443>
 
+    #Add standard site and SSL config here
+
         ProxyPass / http://localhost:8080/
         ProxyPassReverse / http://localhost:8080/
         ProxyPass /static !

--- a/README.rst
+++ b/README.rst
@@ -37,24 +37,30 @@ Proxy configuration
 
 If you wish to run django in a light wsgi container such as uwsgi, gunicorn etc. it is possible to pass the webauth username to the local proxy server by setting an environmental variable in apache as shown below.
 
-The following configuration assumes that the apache mod_proxy is loaded as well as mod_webauth and is placed inside the virtualhost configuration. All directly served URLs such as static must be ignoged by using the syntax shown below
+The following configuration assumes that the apache mod_proxy is loaded as well as mod_webauth and is placed inside the virtualhost configuration. All directly served URLs such as static must be ignoged by using the syntax shown below::
 
     <VirtualHost *:443>
-    ProxyPass / http://localhost:8080/
-    ProxyPassReverse / http://localhost:8080/
-    ProxyPass /static !
-    Alias /static /var/www/chembiohub/chembiohubhome/chembiohub/static
+
+        ProxyPass / http://localhost:8080/
+        ProxyPassReverse / http://localhost:8080/
+        ProxyPass /static !
+        Alias /static /var/www/chembiohub/chembiohubhome/chembiohub/static
+
+
     <Location />
-    WebAuthExtraRedirect on
-    AuthType WebAuth
-    require valid-user
-    RequestHeader set "X-WEBAUTH-USER" "%{WEBAUTH_USER}e"
+      WebAuthExtraRedirect on
+      AuthType WebAuth
+      require valid-user
+      RequestHeader set "X-WEBAUTH-USER" "%{WEBAUTH_USER}e"
     </location>
+
+
     <Directory /path/to/my/site/static>
-    Options Indexes FollowSymLinks Includes
-    AllowOverride All
-    Order allow,deny
-    Allow from all
+        Options Indexes FollowSymLinks Includes
+        AllowOverride All
+        Order allow,deny
+        Allow from all
+
     </Directory>
     </VirtualHost>
 

--- a/README.rst
+++ b/README.rst
@@ -54,16 +54,16 @@ The following configuration assumes that the apache mod_proxy is loaded as well 
       AuthType WebAuth
       require valid-user
       RequestHeader set "X-WEBAUTH-USER" "%{WEBAUTH_USER}e"
-RequestHeader unset X-Forwarded-Proto
+      RequestHeader unset X-Forwarded-Proto
 
-# set the header for requests using HTTPS
-RequestHeader set X-Forwarded-Proto https env=HTTPS
-</location>
+      # set the header for requests using HTTPS
+      RequestHeader set X-Forwarded-Proto https env=HTTPS
+    </location>
 
-RequestHeader unset X-Forwarded-Proto
+    RequestHeader unset X-Forwarded-Proto
 
-# set the header for requests using HTTPS
-RequestHeader set X-Forwarded-Proto https env=HTTPS
+    # set the header for requests using HTTPS
+    RequestHeader set X-Forwarded-Proto https env=HTTPS
 
 
     <Directory /path/to/my/site/static>

--- a/README.rst
+++ b/README.rst
@@ -32,34 +32,31 @@ Follow the `OUCS documentation
 the Webauth login view. You may also wish to use the ``WebauthDoLogout``
 directive for the logout view.
 
-If you wish to run django in a light wsgi container such as uwsgi, gunicorn etc. It is possible to pass the webauth username to the local proxy server by setting an environmental variable in apache.
+Proxy configuration
+~~~~~~~~~~~~~~~~~~~~
+
+If you wish to run django in a light wsgi container such as uwsgi, gunicorn etc. it is possible to pass the webauth username to the local proxy server by setting an environmental variable in apache as shown below.
 
 The following configuration assumes that the apache mod_proxy is loaded as well as mod_webauth and is placed inside the virtualhost configuration. All directly served URLs such as static must be ignoged by using the syntax shown below
 
-<VirtualHost *:443>
-
+    <VirtualHost *:443>
     ProxyPass / http://localhost:8080/
     ProxyPassReverse / http://localhost:8080/
     ProxyPass /static !
     Alias /static /var/www/chembiohub/chembiohubhome/chembiohub/static
-
-
     <Location />
-      WebAuthExtraRedirect on
-      AuthType WebAuth
-      require valid-user
-      RequestHeader set "X-WEBAUTH-USER" "%{WEBAUTH_USER}e"
+    WebAuthExtraRedirect on
+    AuthType WebAuth
+    require valid-user
+    RequestHeader set "X-WEBAUTH-USER" "%{WEBAUTH_USER}e"
     </location>
-
-
-  <Directory /path/to/my/site/static>
-Options Indexes FollowSymLinks Includes
-        AllowOverride All
-        Order allow,deny
-        Allow from all
-
-</Directory>
-</VirtualHost>
+    <Directory /path/to/my/site/static>
+    Options Indexes FollowSymLinks Includes
+    AllowOverride All
+    Order allow,deny
+    Allow from all
+    </Directory>
+    </VirtualHost>
 
 
 As the request header has come from Apache it is prepended with HTTP_ by the time it gets to django hence the get statement in views.py.

--- a/django_webauth/backends.py
+++ b/django_webauth/backends.py
@@ -16,9 +16,6 @@ class WebauthLDAP(object):
                 'ldap://ldap.oak.ox.ac.uk:389')
 
     def authenticate(self, username):
-        user, created = User.objects.get_or_create(username=username)
-        if created:
-            user.set_unusable_password()
         auth = ldap.sasl.gssapi('')
         oakldap = ldap.initialize(self.ldap_endpoint)
         oakldap.start_tls_s()
@@ -28,18 +25,22 @@ class WebauthLDAP(object):
                                    ldap.SCOPE_SUBTREE,
                                    '(oakPrincipal=krbPrincipalName=%s@OX.AC.UK,cn=OX.AC.UK,cn=KerberosRealms,dc=oak,dc=ox,dc=ac,dc=uk)' % username)
 
+        
+
         if not results:
             return None
         person = results[0][1]
-
+        defaults = {}
         for name, key in (('first_name', 'givenName'),
                           ('last_name', 'sn'),
                           ('email', 'mail')):
             try:
-                setattr(user, name, person[key][0])
+                defaults[name] = person[key][0]
             except KeyError, e:
-                setattr(user, name, '')
+                defaults[name] = ''
                 logger.warning("User %s doesn't have a %s", username, key)
+        user, _ = User.objects.get_or_create(username=username, defaults=defaults)
+        user.set_unusable_password()
 
         user.groups = self.get_groups(user, person)
 

--- a/django_webauth/views.py
+++ b/django_webauth/views.py
@@ -19,7 +19,10 @@ class LoginView(View):
     def get(self, request):
         username = request.META.get('REMOTE_USER')
         if not username:
-            raise ImproperlyConfigured('This view is supposed to set a REMOTE_USER environment variable')
+            #get the username if mod_proxy is running in front of django as configured in README.rst
+            username = request.META.get('HTTP_X_WEBAUTH_USER')
+            if not username:   
+                raise ImproperlyConfigured('This view is supposed to set a REMOTE_USER environment variable')
 
         user = authenticate(username=username)
         login(request, user)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 kerberos==1.1.1
+python-ldap


### PR DESCRIPTION
I have added documentation and a small code change to allow for proxy server support e.g. gunicorn, uwsgi etc.
Many developers prefer this setup, might also be useful for languages like:
Node, 
Ruby,
Java and the performance concious php developer...
